### PR TITLE
Fix not working python examples for LIS2DW12

### DIFF
--- a/python/raspberrypi/DFRobot_LIS2DW12.py
+++ b/python/raspberrypi/DFRobot_LIS2DW12.py
@@ -443,7 +443,7 @@ class DFRobot_LIS2DW12(object):
       @n            NO_DETECTION         #No detection
       @n            DETECT_ACT           #Detect movement,the chip automatically goes to 12.5 Hz rate in the low-power mode
       @n            DETECT_STATMOTION    #Detect Motion, the chip detects acceleration below a fixed threshold but does not change either rate or operating mode
-    '''!
+    '''
     value1 = self.read_reg(self.REG_WAKE_UP_THS)
     value2 = self.read_reg(self.REG_WAKE_UP_DUR)
     value1 = value1 & (~(1<<6))
@@ -862,9 +862,9 @@ class DFRobot_IIS2DLPC_I2C(DFRobot_LIS2DW12):
       @param reg register address
       @param data written data
     '''
-        self.i2cbus.write_i2c_block_data(self.__addr ,reg,[data])
-        #self.i2cbus.write_byte(self.__addr ,reg)
-        #self.i2cbus.write_byte(self.__addr ,data)
+    self.i2cbus.write_i2c_block_data(self.__addr ,reg,[data])
+    #self.i2cbus.write_byte(self.__addr ,reg)
+    #self.i2cbus.write_byte(self.__addr ,data)
   
   def read_reg(self, reg):
     '''!
@@ -908,16 +908,16 @@ class DFRobot_IIS2DLPC_SPI(DFRobot_LIS2DW12):
       @param reg register address
       @return read data
     '''
-     GPIO.output(self.__cs, GPIO.LOW)
-     self.__spi.writebytes([reg | self.SPI_READ_BIT])
-     time.sleep(0.01)
-     data = self.__spi.readbytes(1)
-     GPIO.output(self.__cs, GPIO.HIGH)
-     return  data[0]
+    GPIO.output(self.__cs, GPIO.LOW)
+    self.__spi.writebytes([reg | self.SPI_READ_BIT])
+    time.sleep(0.01)
+    data = self.__spi.readbytes(1)
+    GPIO.output(self.__cs, GPIO.HIGH)
+    return  data[0]
   
 class DFRobot_LIS2DW12_I2C(DFRobot_LIS2DW12): 
   def __init__(self ,bus ,addr):
-    self.__addr = addr;
+    self.__addr = addr
     super(DFRobot_LIS2DW12_I2C, self).__init__()
     self.i2cbus = smbus.SMBus(bus)
 

--- a/python/raspberrypi/examples/LIS2DW12/activity_detect/activity_detect.py
+++ b/python/raspberrypi/examples/LIS2DW12/activity_detect/activity_detect.py
@@ -18,7 +18,7 @@
 '''
 
 import sys
-sys.path.append("../..") # set system path to top
+sys.path.append("../../..") # set system path to top
 
 from DFRobot_LIS2DW12 import *
 import time

--- a/python/raspberrypi/examples/LIS2DW12/free_fall/free_fall.py
+++ b/python/raspberrypi/examples/LIS2DW12/free_fall/free_fall.py
@@ -13,7 +13,7 @@
 '''
 
 import sys
-sys.path.append("../..") # set system path to top
+sys.path.append("../../..") # set system path to top
 
 from DFRobot_LIS2DW12 import *
 import time

--- a/python/raspberrypi/examples/LIS2DW12/get_acceleration/get_acceleration.py
+++ b/python/raspberrypi/examples/LIS2DW12/get_acceleration/get_acceleration.py
@@ -16,7 +16,7 @@
 '''
 
 import sys
-sys.path.append("../..") # set system path to top
+sys.path.append("../../..") # set system path to top
 
 from DFRobot_LIS2DW12 import *
 import time

--- a/python/raspberrypi/examples/LIS2DW12/interrupt/interrupt.py
+++ b/python/raspberrypi/examples/LIS2DW12/interrupt/interrupt.py
@@ -13,7 +13,7 @@
 '''
 
 import sys
-sys.path.append("../..") # set system path to top
+sys.path.append("../../..") # set system path to top
 
 from DFRobot_LIS2DW12 import *
 import time

--- a/python/raspberrypi/examples/LIS2DW12/orientation/orientation.py
+++ b/python/raspberrypi/examples/LIS2DW12/orientation/orientation.py
@@ -18,7 +18,7 @@
 '''
 
 import sys
-sys.path.append("../..") # set system path to top
+sys.path.append("../../..") # set system path to top
 
 from DFRobot_LIS2DW12 import *
 import time

--- a/python/raspberrypi/examples/LIS2DW12/tap/tap.py
+++ b/python/raspberrypi/examples/LIS2DW12/tap/tap.py
@@ -13,7 +13,7 @@
 '''
 
 import sys
-sys.path.append("../..") # set system path to top
+sys.path.append("../../..") # set system path to top
 
 from DFRobot_LIS2DW12 import *
 import time

--- a/python/raspberrypi/examples/LIS2DW12/wake_up/wake_up.py
+++ b/python/raspberrypi/examples/LIS2DW12/wake_up/wake_up.py
@@ -16,7 +16,7 @@
 '''
 
 import sys
-sys.path.append("../..") # set system path to top
+sys.path.append("../../..") # set system path to top
 
 from DFRobot_LIS2DW12 import *
 import time


### PR DESCRIPTION
All python examples for LIS2DW12 had broken imports of DFRobot_LIS2DW12.py. Also DFRobot_LIS2DW12.py had incorrect indents and a typo. I've tested and all examples are now working.